### PR TITLE
Fix Floating Point Sum (0)

### DIFF
--- a/src/components/AluModal/FloatingPointSlides/index.jsx
+++ b/src/components/AluModal/FloatingPointSlides/index.jsx
@@ -168,8 +168,8 @@ export const FloatingPointSlides = ({
                 <SignBit>
                   {registerSbits.slice(0, 1) === "0" ? "+" : "-"}
                 </SignBit>
-                {"1."}
-                <MantissaBits>{registerSbits.slice(4)}</MantissaBits>
+
+                <MantissaBits>{parsedS.mantissa.implied}</MantissaBits>
               </BitsRow>
               {"*2^"}
               <ExponentBits>
@@ -198,8 +198,8 @@ export const FloatingPointSlides = ({
                 <SignBit>
                   {registerTbits.slice(0, 1) === "0" ? "+" : "-"}
                 </SignBit>
-                {"1."}
-                <MantissaBits>{registerTbits.slice(4)}</MantissaBits>
+
+                <MantissaBits>{parsedT.mantissa.implied}</MantissaBits>
               </BitsRow>
               {"*2^"}
               <ExponentBits>
@@ -218,8 +218,8 @@ export const FloatingPointSlides = ({
                 <SignBit>
                   {registerSbits.slice(0, 1) === "0" ? "+" : "-"}
                 </SignBit>
-                {"1."}
-                <MantissaBits>{registerSbits.slice(4)}</MantissaBits>
+
+                <MantissaBits>{parsedS.mantissa.implied}</MantissaBits>
               </BitsRow>
               {"*2^"}
               <ExponentBits>
@@ -233,8 +233,8 @@ export const FloatingPointSlides = ({
                 <SignBit>
                   {registerTbits.slice(0, 1) === "0" ? "+" : "-"}
                 </SignBit>
-                {"1."}
-                <MantissaBits>{registerTbits.slice(4)}</MantissaBits>
+
+                <MantissaBits>{parsedT.mantissa.implied}</MantissaBits>
               </BitsRow>
               {"*2^"}
               <ExponentBits>

--- a/src/interpreter/instructions/FloatingPointSum.js
+++ b/src/interpreter/instructions/FloatingPointSum.js
@@ -145,11 +145,15 @@ Exponente sesgado:
 export function parseRegister(register) {
   const sign = parseInt(register[0], 2);
 
-  const exponentStr = register.slice(1, 4);
-  const exponentDecimal = parseInt(exponentStr, 2) - 3;
+  let exponentStr = register.slice(1, 4);
+  let exponentDecimal = parseInt(exponentStr, 2) - 3;
 
-  const mantissa = register.slice(4, 8);
-  const mantissaWithImpliedBit = `1.${mantissa}`;
+  let mantissa = register.slice(4, 8);
+  let mantissaWithImpliedBit = `1.${mantissa}`;
+
+  if (mantissa == "0000" && exponentStr == "000") {
+    mantissaWithImpliedBit = "0.0000";
+  }
 
   return {
     sign,


### PR DESCRIPTION
Fix para cuando un valor de los que se suma en punto flotante es 0 (mantisa = 0000, exponente = 000), entonces que se interprete al valor como 0 y no afecte el resultado. Lo mismo para el caso de ambos son 0. 

Ahora se cumple: 
- 0 + a = a
- 0 + 0 = 0